### PR TITLE
Prepare Swift Talk for archive mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /*.xcodeproj
 *.swp
 .postgres
+.postgres-old
 .swiftpm
 
 # Elastic Beanstalk Files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM swift:5.0.1
-
-RUN echo ""
-
-# workaround to make this work with the swift 5 image: 
-# https://forums.swift.org/t/lldb-install-precludes-installing-python-in-image/24040
-# RUN  mv /usr/lib/python2.7/site-packages /usr/lib/python2.7/dist-packages; ln -s dist-packages /usr/lib/python2.7/site-packages
+FROM --platform=linux/amd64 swift:5.5.1
 
 RUN apt-get update
 RUN apt-get install -y --fix-missing libssl-dev
@@ -14,7 +8,7 @@ WORKDIR /app
 
 COPY assets ./assets
 COPY Package.swift LinuxMain.swift ./
-RUN swift package update
+# RUN swift package update
 
 COPY Sources ./Sources
 COPY Tests ./Tests

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM swift:5.0.1
+FROM --platform=linux/amd64 swift:5.5.1
 
 # workaround to make this work with the swift 5 image: 
 # https://forums.swift.org/t/lldb-install-precludes-installing-python-in-image/24040

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/objcio/LibPQ",
         "state": {
           "branch": "master",
-          "revision": "d261a8f020885c0376b610c014ecfc68907541c1",
+          "revision": "e6fb474d6ddca9873d6ad757798dc7fd26fa916e",
           "version": null
         }
       },
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6a79d4687ede7c088fe3e31d9b3452d6e6cd91eb",
-          "version": "2.5.1"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "EndpointBuilder",
+        "repositoryURL": "https://github.com/chriseidhof/backend-experiments",
+        "state": {
+          "branch": "main",
+          "revision": "5aa66111a41a2585deb43d218a5c7576c9d082f1",
+          "version": null
+        }
+      },
+      {
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,12 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "swifttalk-server",
+    platforms: [
+        .macOS(.v12)
+    ],
     products: [
         .executable(name: "swifttalk-server", targets: ["swifttalk-server"]),
         .library(name: "SwiftTalkServerLib", targets: ["SwiftTalkServerLib"]),
@@ -25,7 +28,8 @@ let package = Package(
         .package(url: "https://github.com/objcio/swift-talk-shared", from: "0.2.0"),
         .package(url: "https://github.com/objcio/md5", .exact("0.1.0")),
         .package(url: "https://github.com/jpsim/SourceKitten", .exact("0.29.0")), // todo 0.29 introduces a breaking change.
-		.package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.0.2"),
+        .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.0.2"),
+        .package(url: "https://github.com/chriseidhof/backend-experiments", .branch("main")),
     ],
     targets: [
         .target(
@@ -49,7 +53,8 @@ let package = Package(
         .target(
             name: "Networking",
             dependencies: [
-			  "TinyNetworking"
+                .product(name: "TinyNetworking", package: "tiny-networking"),
+
             ],
             path: "Sources/Networking"
         ),
@@ -58,9 +63,9 @@ let package = Package(
             dependencies: [
                 "Base",
                 "Promise",
-                "NIO",
-                "NIOHTTP1",
-                "NIOFoundationCompat",
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
             path: "Sources/NIOWrapper"
         ),
@@ -98,8 +103,9 @@ let package = Package(
         .target(
             name: "SwiftTalkServerLib",
             dependencies: [
+//                "EndpointBuilder",
                 "Incremental",
-                "TinyNetworking",
+                .product(name: "TinyNetworking", package: "tiny-networking"),
                 "Networking",
                 "Promise",
                 "Base",
@@ -108,11 +114,11 @@ let package = Package(
                 "NIOWrapper",
                 "Database",
                 "WebServer",
-                "CommonMark",
-				"Model",
-				"ViewHelpers",
+                .product(name: "CommonMark", package: "commonmark-swift"),
+                .product(name: "Model", package: "swift-talk-shared"),
+                .product(name: "ViewHelpers", package: "swift-talk-shared"),
 				"md5",
-				"SourceKittenFramework",
+                .product(name: "SourceKittenFramework", package: "SourceKitten"),
 			],
 			path: "Sources/SwiftTalkServerLib"
 		),
@@ -120,15 +126,15 @@ let package = Package(
             name: "swifttalk-server",
         	dependencies: [
                 "SwiftTalkServerLib",
-				"Backtrace",
+                .product(name: "Backtrace", package: "swift-backtrace")
         	],
 			path: "Sources/swifttalk-server"
         ),
 		.target(
 			name: "highlight-html",
 			dependencies: [
-                "SourceKittenFramework",
-                "CommonMark"
+                .product(name: "SourceKittenFramework", package: "SourceKitten"),
+                .product(name: "CommonMark", package: "commonmark-swift"),
 			],
 			path: "Sources/highlight-html"
 		),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "Incremental", targets: ["Incremental"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .exact("2.5.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", .exact("2.40.0")),
         .package(url: "https://github.com/chriseidhof/commonmark-swift", .branch("embed-c")),
         .package(url: "https://github.com/objcio/LibPQ", .branch("master")),
         .package(url: "https://github.com/objcio/tiny-networking", from: "0.2.0"),

--- a/Sources/SwiftTalkServerLib/Environment.swift
+++ b/Sources/SwiftTalkServerLib/Environment.swift
@@ -61,6 +61,10 @@ struct Env {
     var baseURL: URL { return URL(string: env["BASE_URL"]!)! }
 
     var production: Bool { return env["PRODUCTION"].map(Int.init) == 1 }
+    var localDevelopment: Bool {
+        guard !production, let host = baseURL.host?.lowercased() else { return false }
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    }
     var port: Int? { return env["PORT"].flatMap(Int.init) }
     
     var databaseURL: String? { return env["DATABASE_URL"] }

--- a/Sources/SwiftTalkServerLib/Interpret/InterpretLogin.swift
+++ b/Sources/SwiftTalkServerLib/Interpret/InterpretLogin.swift
@@ -16,6 +16,29 @@ extension Route.Login {
         switch self {
         
         case .login(let cont):
+            if env.localDevelopment {
+                let destination = cont?.path ?? "/"
+                func createSession(userId: UUID) -> I {
+                    return .query(SessionData(userId: userId).insert) { sessionId in
+                        .redirect(path: destination, headers: ["Set-Cookie": "sessionid=\"\(sessionId.uuidString)\"; HttpOnly; Path=/"])
+                    }
+                }
+
+                return .query(Row<UserData>.select(githubLogin: "local-preview")) { user in
+                    if let user = user {
+                        return createSession(userId: user.id)
+                    }
+                    let previewUser = UserData(
+                        email: "local-preview@localhost.invalid",
+                        githubLogin: "local-preview",
+                        avatarURL: "",
+                        name: "Local Preview",
+                        confirmedNameAndEmail: true
+                    )
+                    return .query(previewUser.insert, createSession)
+                }
+            }
+
             var path = "https://github.com/login/oauth/authorize?scope=user:email&client_id=\(github.clientId)"
             if let c = cont {
                 let encoded = env.baseURL.absoluteString + Route.login(.githubCallback(code: nil, origin: c.path)).path

--- a/Sources/SwiftTalkServerLib/Interpret/InterpretSignup.swift
+++ b/Sources/SwiftTalkServerLib/Interpret/InterpretSignup.swift
@@ -22,17 +22,17 @@ extension Route.Signup {
                     return I.redirect(to: .subscription(.new(couponCode: nil, planCode: p, team: false)))
                 }
             } else {
-                guard let monthly = Plan.monthly, let yearly = Plan.yearly else {
-                    throw ServerError(privateMessage: "Can't find monthly or yearly plan: \([Plan.all])")
+                guard let monthly = Plan.monthly else {
+                    throw ServerError(privateMessage: "Can't find monthly plan: \([Plan.all])")
                 }
-                return .write(html: renderSubscribe(monthly: monthly, yearly: yearly))
+                return .write(html: renderSubscribe(monthly: monthly))
             }
         
         case .subscribeTeam:
-            guard let monthly = Plan.monthly, let yearly = Plan.yearly else {
-                throw ServerError(privateMessage: "Can't find monthly or yearly plan: \([Plan.all])")
+            guard let monthly = Plan.monthly else {
+                throw ServerError(privateMessage: "Can't find monthly plan: \([Plan.all])")
             }
-            return .write(html: renderSubscribeTeam(monthly: monthly, yearly: yearly))
+            return .write(html: renderSubscribeTeam(monthly: monthly))
         
         case .teamMember(let token):
             return .query(Row<UserData>.select(teamToken: token)) { row in
@@ -59,10 +59,10 @@ extension Route.Signup {
                 guard coupon.state == "redeemable" else {
                     throw ServerError(privateMessage: "not redeemable: \(str)", publicMessage: "This coupon is not redeemable anymore.", status: HTTPResponseStatus.forbidden)
                 }
-                guard let m = Plan.monthly, let y = Plan.yearly else {
+                guard let monthly = Plan.monthly else {
                     throw ServerError(privateMessage: "Plans not loaded", publicMessage: "A small hiccup. Please try again in a little while.")
                 }
-                return .write(html: renderSubscribe(monthly: m, yearly: y, coupon: coupon))
+                return .write(html: renderSubscribe(monthly: monthly, coupon: coupon))
             })
         }
     }

--- a/Sources/SwiftTalkServerLib/Interpret/InterpretSubscription.swift
+++ b/Sources/SwiftTalkServerLib/Interpret/InterpretSubscription.swift
@@ -25,10 +25,10 @@ extension Route.Subscription {
             if let p = planCode, let plan = Plan.find(code: p), plan.isEnterprisePlan {
                 return try I.write(html: newSub(coupon: nil, team: team, plans: [plan], error: error))
             }
-            guard let m = Plan.monthly, let y = Plan.yearly else {
-                throw ServerError(privateMessage: "No monthly or yearly plan: \(Plan.all)", publicMessage: "Something went wrong, we're on it. Please check back at a later time.")
+            guard let monthly = Plan.monthly else {
+                throw ServerError(privateMessage: "No monthly plan: \(Plan.all)", publicMessage: "Something went wrong, we're on it. Please check back at a later time.")
             }
-            let plans = [m,y]
+            let plans = [monthly]
             if let c = couponCode {
                 return .onSuccess(promise: recurly.coupon(code: c).promise, do: { coupon in
                     return try .write(html: newSub(coupon: coupon, team: team, plans: plans, error: error))

--- a/Sources/SwiftTalkServerLib/Interpret/InterpretSubscription.swift
+++ b/Sources/SwiftTalkServerLib/Interpret/InterpretSubscription.swift
@@ -84,12 +84,10 @@ extension Route.Subscription {
                 let resp = registerForm(couponCode: couponCode, planCode: planCode, team: team).render(.init(user.data), [])
                 return .write(html: resp)
             } else {
-                return .query(Task.unfinishedSubscriptionReminder(userId: user.id).schedule(weeks: 1)) {
-                    var u = user
-                    u.data.role = team ? .teamManager : .user
-                    return .query(u.update()) {
-                        try newSubscription(couponCode: couponCode, planCode: planCode, team: team)
-                    }
+                var u = user
+                u.data.role = team ? .teamManager : .user
+                return .query(u.update()) {
+                    try newSubscription(couponCode: couponCode, planCode: planCode, team: team)
                 }
             }
         

--- a/Sources/SwiftTalkServerLib/ScheduledTasks.swift
+++ b/Sources/SwiftTalkServerLib/ScheduledTasks.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Promise
 import Base
 import Database
 import Networking
@@ -138,32 +137,10 @@ extension Task {
                 onCompletion((s.subscription_add_ons?.first?.quantity ?? 0) == max(memberCount, 0)) // todo the `max` is necessary because memberCount might be -1
             })
         
-        case .releaseEpisode(let number):
-            if mailchimp.apiKey == "test" { onCompletion(true); return } // don't release episodes in test environments
-            guard let ep = Episode.all.first(where: { $0.number == number }) else { onCompletion(true); return }
-            let sendCampaign: Promise<Bool> = globals.urlSession.load(mailchimp.createCampaign(for: ep)).flatMap { campaignId in
-                guard let id = campaignId else { return Promise { $0(false) } }
-                return globals.urlSession.load(mailchimp.addContent(for: ep, toCampaign: id)).flatMap { _ in
-                    if env.production {
-                        return globals.urlSession.load(mailchimp.sendCampaign(campaignId: id)).map { $0 != nil }
-                    } else {
-                        return globals.urlSession.load(mailchimp.testCampaign(campaignId: id)).map { $0 != nil }
-                    }
-                }
-            }
-
+        case .releaseEpisode:
+            // Legacy task: episodes are no longer released through a GitHub repository or email campaign.
             onCompletion(true)
 
-            globals.urlSession.load(github.changeVisibility(private: false, of: ep.id.rawValue)).flatMap { _ in
-                globals.urlSession.load(mailchimp.existsCampaign(for: ep))
-            }.flatMap { campaignExists in
-                return campaignExists == false ? sendCampaign : Promise { $0(false) }
-            }.run { success in
-                if !success {
-                    log(error: "Something went wrong while releasing episode \(number).")
-                }
-            }
-        
         case .unfinishedSubscriptionReminder:
             // Legacy task: discard reminders that were queued before the archive-mode change.
             onCompletion(true)

--- a/Sources/SwiftTalkServerLib/ScheduledTasks.swift
+++ b/Sources/SwiftTalkServerLib/ScheduledTasks.swift
@@ -198,7 +198,7 @@ Hi!
 
 We noticed that you signed up for Swift Talk a while ago, but never finished your registration. We'd love for you to become a subscriber.
 
-Use the following link to get a 20% discount: https://talk.objc.io/promo/swift-talk-discount (you'll get 20% off of the first three months, or if you choose a yearly plan, 20% off of your first year).
+Use the following link to get a 20% discount: https://talk.objc.io/promo/swift-talk-discount (you'll get 20% off of the first three months).
 
 If you have any questions, let us know.
 

--- a/Sources/SwiftTalkServerLib/ScheduledTasks.swift
+++ b/Sources/SwiftTalkServerLib/ScheduledTasks.swift
@@ -164,10 +164,9 @@ extension Task {
                 }
             }
         
-        case .unfinishedSubscriptionReminder(let userId):
-            guard let user = try c.get().execute(Row<UserData>.select(userId)), !user.data.subscriber else { onCompletion(true); return }
-            let ep = sendgrid.send(to: user.data.email, name: user.data.name, subject: "Your Swift Talk Registration", text: unfinishedSubscriptionReminderText)
-            globals.urlSession.load(ep) { onCompletion($0 != nil)}
+        case .unfinishedSubscriptionReminder:
+            // Legacy task: discard reminders that were queued before the archive-mode change.
+            onCompletion(true)
         }
     }
 }
@@ -192,16 +191,3 @@ extension Row where Element == TaskData {
         }
     }
 }
-
-fileprivate let unfinishedSubscriptionReminderText = """
-Hi!
-
-We noticed that you signed up for Swift Talk a while ago, but never finished your registration. We'd love for you to become a subscriber.
-
-Use the following link to get a 20% discount: https://talk.objc.io/promo/swift-talk-discount (you'll get 20% off of the first three months).
-
-If you have any questions, let us know.
-
-Best from Berlin,
-Florian and Chris
-"""

--- a/Sources/SwiftTalkServerLib/Static/StaticData.swift
+++ b/Sources/SwiftTalkServerLib/Static/StaticData.swift
@@ -77,12 +77,16 @@ fileprivate let transcriptsSource: Static<[Transcript]> = Static(async: { cb in
 
 fileprivate let plansSource: Static<[Plan]> = Static(async: { cb in
     let jsonName = "plans.json"
-    let initial: [Plan] = loadStaticData(name: jsonName)
+    let initial: [Plan] = loadStaticData(name: jsonName, decoder: JSONDecoder())
     cb(initial, false)
     globals.urlSession.load(recurly.plans) { value in
-        cb(try? value.get(), true)
-        guard let v = try? value.get() else { log(error: "Could not load plans from Recurly \(value)"); return }
-        cacheStaticData(v, name: jsonName)
+        guard let plans = try? value.get() else {
+            log(error: "Could not load plans from Recurly \(value)")
+            cb(initial, true)
+            return
+        }
+        cb(plans, true)
+        cacheStaticData(plans, name: jsonName, encoder: JSONEncoder())
     }
 })
 
@@ -276,4 +280,3 @@ extension Transcript {
         return transcripts.value.first { $0.number == number }
     }
 }
-

--- a/Sources/SwiftTalkServerLib/Static/StaticHelpers.swift
+++ b/Sources/SwiftTalkServerLib/Static/StaticHelpers.swift
@@ -27,20 +27,20 @@ extension Collection: StaticLoadable {
     static var jsonName: String { return "collections.json" }
 }
 
-func loadStaticData<A: Codable>(name: String) -> [A] {
+func loadStaticData<A: Codable>(name: String, decoder: JSONDecoder = Github.staticDataDecoder) -> [A] {
     return tryOrLog { try postgres.withConnection { connection in
         guard
             let row = try connection.execute(Row<FileData>.staticData(jsonName: name)),
-            let result = try? Github.staticDataDecoder.decode([A].self, from: row.data.value.data(using: .utf8)!)
+            let result = try? decoder.decode([A].self, from: row.data.value.data(using: .utf8)!)
             else { return [] }
         return result
     }} ?? []
 }
 
-func cacheStaticData<A: Codable>(_ data: A, name: String) {
+func cacheStaticData<A: Codable>(_ data: A, name: String, encoder: JSONEncoder = Github.staticDataEncoder) {
     tryOrLog { try postgres.withConnection { connection in
         guard
-            let encoded = try? Github.staticDataEncoder.encode(data),
+            let encoded = try? encoder.encode(data),
             let json = String(data: encoded, encoding: .utf8)
             else { log(error: "Unable to encode static data \(name)"); return }
         let fd = FileData(repository: github.staticDataRepo, path: name, value: json, sha: nil)
@@ -109,4 +109,3 @@ func refreshTranscripts(knownShas: [String], onCompletion: @escaping () -> ()) {
         }}
     })
 }
-

--- a/Sources/SwiftTalkServerLib/Views/Home.swift
+++ b/Sources/SwiftTalkServerLib/Views/Home.swift
@@ -10,8 +10,16 @@ import HTML
 
 
 func renderHome(episodes: [EpisodeWithProgress]) -> Node {
-    let metaDescription = "A weekly video series on Swift programming by Chris Eidhof and Florian Kugler. objc.io publishes books, videos, and articles on advanced techniques for iOS and macOS development."
-    let header = pageHeader(HeaderContent.other(header: "Swift Talk", blurb: "A weekly video series on Swift programming.", extraClasses: "ms4"))
+    let metaDescription = "A video series on Swift programming by Chris Eidhof and Florian Kugler. objc.io publishes books, videos, and articles on advanced techniques for iOS and macOS development."
+    let header = Node.header(class: "bgcolor-blue pattern-shade", [
+        .div(class: "container", [
+            .h1(class: "color-white bold ms4", ["Swift Talk"]),
+            .p(class: "mt--", [
+                .span(class: "label smallcaps color-blue-darkest bgcolor-orange", ["Archive Mode"])
+            ]),
+            .p(class: "ms2 color-darken-50 lh-110 mw7 mt-", ["A video series on Swift programming."])
+        ])
+    ])
     var recentNodes: [Node] = [
         .header(class: "mb+", [
             .h2(class: "inline-block bold color-black", ["Recent Episodes"]),
@@ -53,4 +61,3 @@ func renderHome(episodes: [EpisodeWithProgress]) -> Node {
     ])
     return LayoutConfig(contents: [header, recentEpisodes, collections], description: metaDescription).layout
 }
-

--- a/Sources/SwiftTalkServerLib/Views/Home.swift
+++ b/Sources/SwiftTalkServerLib/Views/Home.swift
@@ -15,7 +15,11 @@ func renderHome(episodes: [EpisodeWithProgress]) -> Node {
         .div(class: "container", [
             .h1(class: "color-white bold ms4", ["Swift Talk"]),
             .p(class: "mt--", [
-                .span(class: "label smallcaps color-blue-darkest bgcolor-orange", ["Archive Mode"])
+                .link(
+                    to: URL(string: "https://www.objc.io/blog/2026/09/04/the-end-of-swift-talk")!,
+                    class: "label smallcaps color-blue-darkest bgcolor-orange no-decoration",
+                    ["Archive Mode"]
+                )
             ]),
             .p(class: "ms2 color-darken-50 lh-110 mw7 mt-", ["A video series on Swift programming."])
         ])

--- a/Sources/SwiftTalkServerLib/Views/Layout.swift
+++ b/Sources/SwiftTalkServerLib/Views/Layout.swift
@@ -244,7 +244,7 @@ func flash(message: String, type: FlashType) -> Node {
 
 func userHeader(_ session: Session?) -> Node {
     let subscribeButton = Node.li(class: "flex items-center ml+", [
-        .link(to: .signup(.subscribe(planName: nil)), class: "button button--tight button--themed fz-nav", ["Subscribe"])
+        .link(to: .signup(.subscribe(planName: nil)), class: "fz-nav color-gray-30 color-theme-nav hover-color-theme-highlight no-decoration", ["Subscribe"])
     ])
     
     func link(to route: Route, text: String) -> Node {

--- a/Sources/SwiftTalkServerLib/Views/Subscribe.swift
+++ b/Sources/SwiftTalkServerLib/Views/Subscribe.swift
@@ -194,7 +194,7 @@ fileprivate func smallPrint(_ lines: [Node]) -> Node {
 }
 
 func newSub(coupon: Coupon?, team: Bool, plans: [Plan], error: RecurlyError? = nil) throws -> Node {
-    let data = SubscriptionFormData(plans: plans, selectedPlan: plans[0], coupon: coupon, error: error)
+    let data = SubscriptionFormData(plans: plans, selectedPlan: plans[0], team: team, coupon: coupon, error: error)
     return LayoutConfig(contents: [
         .header([
             .div(class: "container-h pb+ pt+", [

--- a/Sources/SwiftTalkServerLib/Views/Subscribe.swift
+++ b/Sources/SwiftTalkServerLib/Views/Subscribe.swift
@@ -12,10 +12,17 @@ import WebServer
 
 
 let subscriptionBenefits: [(icon: String, name: String, description: String)] = [
-    ("icon-benefit-unlock.svg", "Watch All Episodes", "A new episode every week"),
+    ("icon-benefit-unlock.svg", "Watch All Episodes", "Access to the full archive"),
     ("icon-benefit-download.svg", "Download Episodes", "Take Swift Talk with you when you're offline"),
-    ("icon-benefit-support.svg", "Support Us", "With your help we can keep producing new episodes"),
+    ("icon-benefit-support.svg", "Support Us", "Help us keep the full archive available"),
 ]
+
+let recordingEndedBanner = Node.div(class: "bgcolor-invalid text-center color-white pa- lh-125 radius-3", [
+    .p(class: "bold", [
+        .span(class: "block", ["We're not recording new episodes anymore."]),
+        .span(class: "block", ["Subscribe to get access to the full archive."])
+    ])
+])
 
 
 func benefits(_ items: [(icon: String, name: String, description: String)]) -> Node {
@@ -90,11 +97,12 @@ fileprivate func continueLink(session: Session?, coupon: Coupon?, team: Bool) ->
     } else if session?.user != nil {
         return continueLink(to: .subscription(.new(couponCode: coupon?.coupon_code, planCode: nil, team: team)), title: "Proceed to payment")
     } else {
-        return continueLink(to: .login(.login(continue: Route.subscription(.new(couponCode: coupon?.coupon_code, planCode: nil, team: team)))), title: "Sign in with Github")
+        let title = env.localDevelopment ? "Sign in locally" : "Sign in with Github"
+        return continueLink(to: .login(.login(continue: Route.subscription(.new(couponCode: coupon?.coupon_code, planCode: nil, team: team)))), title: title)
     }
 }
 
-func renderSubscribe(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> Node {
+func renderSubscribe(monthly: Plan, coupon: Coupon? = nil) -> Node {
     return .withSession { session in
         let contents: [Node] = [
             pageHeader(.other(header: "Subscribe to Swift Talk", blurb: nil, extraClasses: "ms5 pv---"), extraClasses: "text-center pb+++ n-mb+++"),
@@ -109,12 +117,12 @@ func renderSubscribe(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> Node
                     .div(class: "pattern-gradient pattern-gradient--swifttalk pv++ ph+ radius-5", [
                         .div(class: "flex items-center justify-around text-center color-white", [
                             monthly.priceBox(coupon: coupon),
-                            yearly.priceBox(coupon: coupon),
                         ])
                     ]),
                     .div([
                         continueLink(session: session, coupon: coupon, team: false)
-                    ])
+                    ]),
+                    recordingEndedBanner
                 ]),
                 benefits(subscriptionBenefits),
                 .ul(class: "text-center max-width-7 center pt++ pb++", [
@@ -140,7 +148,7 @@ func renderSubscribe(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> Node
     }
 }
 
-func renderSubscribeTeam(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> Node {
+func renderSubscribeTeam(monthly: Plan, coupon: Coupon? = nil) -> Node {
     return .withSession { session in
         let contents: [Node] = [
             pageHeader(.other(header: "Swift Talk Team Subscription", blurb: nil, extraClasses: "ms5 pv---"), extraClasses: "text-center pb+++ n-mb+++"),
@@ -155,15 +163,15 @@ func renderSubscribeTeam(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> 
                     .div(class: "pattern-gradient pattern-gradient--swifttalk pv++ ph+ radius-5", [
                         .div(class: "flex items-center justify-around text-center color-white", [
                             monthly.priceBox(coupon: coupon, team: true),
-                            yearly.priceBox(coupon: coupon, team: true),
                         ])
                     ]),
                     .div([
                         continueLink(session: session, coupon: coupon, team: true)
-                    ])
+                    ]),
+                    recordingEndedBanner
                 ]),
                 benefits([
-                    ("icon-benefit-unlock.svg", "Watch All Episodes", "A new episode every week"),
+                    ("icon-benefit-unlock.svg", "Watch All Episodes", "Access to the full archive"),
                     ("icon-benefit-manager.svg", "Team Manager Account", "A central account to manage billing and team members"),
                     ("icon-benefit-download.svg", "Download Episodes", "Take Swift Talk with you when you're offline"),
                 ]),
@@ -179,7 +187,7 @@ func renderSubscribeTeam(monthly: Plan, yearly: Plan, coupon: Coupon? = nil) -> 
                     ]),
                 .div(class: "ms-1 color-gray-65 lh-110 text-center center pt+ max-width-8", [
                     smallPrint([
-                        .span([.raw("<sup>*</sup>"), "Prices apply from the 2nd team member. The first team member is included in the subscription base price, \(monthly.discountedPrice(coupon: coupon).plainText)/month or \(yearly.discountedPrice(coupon: coupon).plainText)/year"]),
+                        .span([.raw("<sup>*</sup>"), "Prices apply from the 2nd team member. The first team member is included in the subscription base price, \(monthly.discountedPrice(coupon: coupon).plainText)/month"]),
                         "All prices shown excluding VAT (only applies to EU customers).",
                     ])
                 ])
@@ -204,4 +212,3 @@ func newSub(coupon: Coupon?, team: Bool, plans: [Plan], error: RecurlyError? = n
         subscriptionForm(data, action: .subscription(.create(couponCode: coupon?.coupon_code, team: team)))
     ], includeRecurlyJS: true).layoutForCheckout
 }
-

--- a/Sources/SwiftTalkServerLib/Views/SubscriptionForm.swift
+++ b/Sources/SwiftTalkServerLib/Views/SubscriptionForm.swift
@@ -208,11 +208,14 @@ struct SubscriptionFormData: Encodable {
         self.belowButtonText = "Your card will be billed on \(startDate)."
     }
     
-    init(plans: [Plan], selectedPlan: Plan, coupon: SwiftTalkServerLib.Coupon? = nil, error: RecurlyError? = nil) {
+    init(plans: [Plan], selectedPlan: Plan, team: Bool, coupon: SwiftTalkServerLib.Coupon? = nil, error: RecurlyError? = nil) {
         self.plans = plans.map { .init($0) }
         self.plan = selectedPlan.plan_code
         self.errorMessages = error.map { [$0.transaction_error.customer_message] } ?? [];
         self.coupon = JSONOptional(coupon.map { .init($0) })
+        if team {
+            self.belowButtonText = "You can add team members after subscribing."
+        }
     }
 }
 

--- a/Tests/swifttalkTests/Flows.swift
+++ b/Tests/swifttalkTests/Flows.swift
@@ -154,7 +154,6 @@ final class FlowTests: XCTestCase {
                 try $0.withSession(confirmedSess) {
                     try $0.followRequests {
                         try $0.followRedirect(to: .subscription(.new(couponCode: nil, planCode: nil, team: false)), expectedQueries: [
-                            QueryAndResult(Task.unfinishedSubscriptionReminder(userId: confirmedSess.user.id).schedule(weeks: 1)),
                             QueryAndResult(query: confirmedSess.user.update(), response: ()),
                         ]) { _ in XCTAssert(true) }
                     }
@@ -184,7 +183,6 @@ final class FlowTests: XCTestCase {
                 try $0.withSession(confirmedSess) {
                     try $0.followRequests {
                         try $0.followRedirect(to: .subscription(.new(couponCode: nil, planCode: nil, team: true)), expectedQueries: [
-                            QueryAndResult(Task.unfinishedSubscriptionReminder(userId: confirmedSess.user.id).schedule(weeks: 1)),
                             QueryAndResult(confirmedSess.user.update())
                         ]) { _ in XCTAssert(true) }
                     }

--- a/Tests/swifttalkTests/TestBase.swift
+++ b/Tests/swifttalkTests/TestBase.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 import Base
+import Database
+import WebServer
 import XCTest
+@testable import SwiftTalkServerLib
 
 final class TestBase: XCTestCase {
     func testDecodeFormData() {
@@ -20,5 +23,55 @@ final class TestBase: XCTestCase {
             "commit": "Update Profile"
         ]
         XCTAssertEqual(result, expected)
+    }
+
+    func testSubscribeOnlyShowsMonthlyArchiveAccess() throws {
+        pushTestEnv()
+        let requestEnvironment = STRequestEnvironment(
+            route: .signup(.subscribe(planName: nil)),
+            hashedAssetName: { $0 },
+            buildSession: { nil },
+            connection: noConnection,
+            resourcePaths: resourcePaths
+        )
+        let html = renderSubscribe(monthly: plans[0]).htmlDocument(input: requestEnvironment)
+
+        XCTAssertTrue(html.contains("monthly"))
+        XCTAssertFalse(html.contains("yearly"))
+        XCTAssertTrue(html.contains("Access to the full archive"))
+        XCTAssertFalse(html.contains("A new episode every week"))
+        XCTAssertTrue(html.contains("Help us keep the full archive available"))
+        XCTAssertFalse(html.contains("keep producing new episodes"))
+        let signIn = try XCTUnwrap(html.range(of: "Sign in with Github"))
+        let firstBannerLine = try XCTUnwrap(html.range(of: "We&#39;re not recording new episodes anymore."))
+        let secondBannerLine = try XCTUnwrap(html.range(of: "Subscribe to get access to the full archive."))
+        XCTAssertLessThan(signIn.lowerBound, firstBannerLine.lowerBound)
+        XCTAssertLessThan(firstBannerLine.lowerBound, secondBannerLine.lowerBound)
+        XCTAssertTrue(html.contains("bgcolor-invalid text-center"))
+    }
+
+    func testCachedPlansDecodeWithRecurlyKeys() throws {
+        let json = #"[{"plan_interval_unit":"months","unit_amount_in_cents":{"USD":1500},"plan_interval_length":1,"plan_code":"monthly_plan","name":"Monthly Plan"}]"#
+        let decoded = try JSONDecoder().decode([Plan].self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.first?.plan_code, "monthly_plan")
+        XCTAssertEqual(decoded.first?.unit_amount_in_cents.usdCents, 1500)
+    }
+
+    func testHomeShowsArchiveMode() {
+        pushTestEnv()
+        let requestEnvironment = STRequestEnvironment(
+            route: .home,
+            hashedAssetName: { $0 },
+            buildSession: { nil },
+            connection: noConnection,
+            resourcePaths: resourcePaths
+        )
+        let html = renderHome(episodes: []).htmlDocument(input: requestEnvironment)
+
+        XCTAssertTrue(html.contains("label smallcaps color-blue-darkest bgcolor-orange"))
+        XCTAssertTrue(html.contains("Archive Mode"))
+        XCTAssertTrue(html.contains("A video series on Swift programming."))
+        XCTAssertFalse(html.contains("weekly video series"))
     }
 }

--- a/Tests/swifttalkTests/TestBase.swift
+++ b/Tests/swifttalkTests/TestBase.swift
@@ -69,8 +69,9 @@ final class TestBase: XCTestCase {
         )
         let html = renderHome(episodes: []).htmlDocument(input: requestEnvironment)
 
-        XCTAssertTrue(html.contains("label smallcaps color-blue-darkest bgcolor-orange"))
+        XCTAssertTrue(html.contains("label smallcaps color-blue-darkest bgcolor-orange no-decoration"))
         XCTAssertTrue(html.contains("Archive Mode"))
+        XCTAssertTrue(html.contains("https://www.objc.io/blog/2026/09/04/the-end-of-swift-talk"))
         XCTAssertTrue(html.contains("A video series on Swift programming."))
         XCTAssertFalse(html.contains("weekly video series"))
     }

--- a/Tests/swifttalkTests/TestTasks.swift
+++ b/Tests/swifttalkTests/TestTasks.swift
@@ -46,6 +46,21 @@ final class TaskTests: XCTestCase {
         urlSession.assertDone()
     }
 
+    func testUnfinishedSubscriptionReminderIsDiscarded() throws {
+        let urlSession = TestURLSession([])
+        setupGlobals(session: urlSession)
+        let connection = TestConnection([])
+        var completed = false
+
+        try Task.unfinishedSubscriptionReminder(userId: UUID()).interpret(connection.lazy) {
+            completed = $0
+        }
+
+        XCTAssertTrue(completed)
+        connection.assertDone()
+        urlSession.assertDone()
+    }
+
 //    func testSyncTeamMembersBillsMinusOneTeamMembersForTeamManager() throws {
 //        let user = subscribedTeamManager.user
 //        let urlSession = teamMembersURLSession(user: user, numberOfTeamMembers: 1)

--- a/Tests/swifttalkTests/TestTasks.swift
+++ b/Tests/swifttalkTests/TestTasks.swift
@@ -61,6 +61,21 @@ final class TaskTests: XCTestCase {
         urlSession.assertDone()
     }
 
+    func testEpisodeReleaseIsDiscarded() throws {
+        let urlSession = TestURLSession([])
+        setupGlobals(session: urlSession)
+        let connection = TestConnection([])
+        var completed = false
+
+        try Task.releaseEpisode(number: 999).interpret(connection.lazy) {
+            completed = $0
+        }
+
+        XCTAssertTrue(completed)
+        connection.assertDone()
+        urlSession.assertDone()
+    }
+
 //    func testSyncTeamMembersBillsMinusOneTeamMembersForTeamManager() throws {
 //        let user = subscribedTeamManager.user
 //        let urlSession = teamMembersURLSession(user: user, numberOfTeamMembers: 1)


### PR DESCRIPTION
Summary
- remove yearly subscriptions from signup and checkout
- replace weekly-release messaging with archive-access copy
- add the recording-ended signup notice and a linked Archive Mode homepage badge
- link Archive Mode to the objc.io end-of-Swift-Talk announcement
- reduce the prominence of the navigation Subscribe link
- disable unfinished-subscription promo emails and harmlessly discard legacy queued reminders
- disable scheduled episode release side effects, including Mailchimp campaigns and GitHub repository visibility changes
- preserve cached plans when Recurly is unavailable and use Recurly-compatible cache encoding
- add a loopback-only local preview login; production OAuth is unchanged

Validation
- swift build
- swift test --filter TestBase
- swift test --filter TaskTests
- manual verification of /, /subscribe, and local session login on port 8766

Known test-suite issue
The legacy subscription flow tests abort in Sources/Base/Logging.swift because synchronizeFile() fails against stderr on the current macOS; this predates these changes.

Base note
This repository has no main branch; its default branch is master, so this PR targets master. The production-matching baseline is c468f9a, which means the PR also carries its three prerequisite commits: Team message, Package updates, and Swift 5.5 changes.