### PR TITLE
Use pinned dependencies in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y postgresql libpq-dev cmake
 WORKDIR /app
 
 COPY assets ./assets
-COPY Package.swift LinuxMain.swift ./
+COPY Package.swift Package.resolved LinuxMain.swift ./
 # RUN swift package update
 
 COPY Sources ./Sources


### PR DESCRIPTION
The production Docker build currently ignores Package.resolved. As a result, Swift 5.5 fetches the current backend-experiments main branch, which now requires Swift 5.7, and the image cannot be built.\n\nThis copies the existing lockfile into the image so production uses the dependencies already verified by the project.