### PR TITLE
Build production image on Heroku

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "EndpointBuilder",
-        "repositoryURL": "https://github.com/chriseidhof/backend-experiments",
-        "state": {
-          "branch": "main",
-          "revision": "5aa66111a41a2585deb43d218a5c7576c9d082f1",
-          "version": null
-        }
-      },
-      {
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
         .package(url: "https://github.com/objcio/md5", .exact("0.1.0")),
         .package(url: "https://github.com/jpsim/SourceKitten", .exact("0.29.0")), // todo 0.29 introduces a breaking change.
         .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.0.2"),
-        .package(url: "https://github.com/chriseidhof/backend-experiments", .branch("main")),
     ],
     targets: [
         .target(
@@ -103,7 +102,6 @@ let package = Package(
         .target(
             name: "SwiftTalkServerLib",
             dependencies: [
-//                "EndpointBuilder",
                 "Incremental",
                 .product(name: "TinyNetworking", package: "tiny-networking"),
                 "Networking",

--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ To build the stylesheets:
 
 ### Deployment
 
-We deploy to a heroku-based docker app (needs postgres as well).
-
-If you get a "basic auth" error: `heroku container:login`
+We deploy to a Heroku-based Docker app (needs Postgres as well). Heroku builds the
+image remotely using `heroku.yml`, which ensures it is built for the supported
+x86_64 runtime architecture.
 
 ```sh
-heroku container:push web
-heroku container:release web
+git push heroku master
 ```
 
 ### Running in Docker

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
Summary\n- remove the unused backend-experiments dependency, whose pinned revision requires Swift 5.7\n- add heroku.yml so Heroku builds the Dockerfile natively for its required x86_64 runtime\n- document the remote deployment command\n\nValidation\n- swift test --filter TaskTests\n- dependency resolution succeeds without backend-experiments\n\nThe local production Docker build cannot complete on this Apple Silicon Mac because its old x86_64 emulator crashes during sustained Swift compilation; the Heroku remote builder avoids that architecture-emulation failure.