### PR TITLE
Update TinyNetworking for Linux builds

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/objcio/tiny-networking",
         "state": {
           "branch": null,
-          "revision": "6676e026109376e6aa51af4830cc5eab57397573",
-          "version": "0.3.0"
+          "revision": "a9af2917018e513c77061139fe3ce4e4d67cf259",
+          "version": "0.4.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .exact("2.40.0")),
         .package(url: "https://github.com/chriseidhof/commonmark-swift", .branch("embed-c")),
         .package(url: "https://github.com/objcio/LibPQ", .branch("master")),
-        .package(url: "https://github.com/objcio/tiny-networking", from: "0.2.0"),
+        .package(url: "https://github.com/objcio/tiny-networking", .exact("0.4.1")),
         .package(url: "https://github.com/objcio/swift-talk-shared", from: "0.2.0"),
         .package(url: "https://github.com/objcio/md5", .exact("0.1.0")),
         .package(url: "https://github.com/jpsim/SourceKitten", .exact("0.29.0")), // todo 0.29 introduces a breaking change.


### PR DESCRIPTION
The Heroku-native Docker build reaches Swift compilation but fails because TinyNetworking 0.3.0 predates its FoundationNetworking import. Pin 0.4.1, which includes Linux support and still declares Swift tools 5.0.\n\nValidation: swift test --filter TaskTests