### PR TITLE
Import FoundationNetworking on Linux

### DIFF
--- a/Sources/Networking/Endpoint.swift
+++ b/Sources/Networking/Endpoint.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import TinyNetworking
 
 public protocol URLSessionProtocol {

--- a/Sources/SwiftTalkServerLib/Environment.swift
+++ b/Sources/SwiftTalkServerLib/Environment.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Networking
 
 

--- a/Tests/swifttalkTests/TestHelpers.swift
+++ b/Tests/swifttalkTests/TestHelpers.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Promise
 import Base
 import XCTest
@@ -206,4 +209,3 @@ extension URLRequest {
         return url == other.url && httpMethod == other.httpMethod && allHTTPHeaderFields == other.allHTTPHeaderFields && httpBody == other.httpBody
     }
 }
-


### PR DESCRIPTION
## Summary
- import FoundationNetworking where URLSession types are used on Linux
- keep the imports conditional so macOS builds are unchanged

## Verification
- `swift test --filter TaskTests`
- production Docker build reached this code after PR #131 and identified these missing imports