### PR TITLE
Import FoundationXML on Linux

### DIFF
--- a/Sources/SwiftTalkServerLib/ThirdPartyServices/RecurlyXMLDecoder.swift
+++ b/Sources/SwiftTalkServerLib/ThirdPartyServices/RecurlyXMLDecoder.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
 import HTML
 
 


### PR DESCRIPTION
## Summary
- import FoundationXML conditionally in the Recurly XML decoder
- restore XMLDocument, XMLElement, and XMLNode APIs on Linux without changing macOS behavior

## Verification
- `swift build`
- `swift test --filter TaskTests`
- Heroku native build compiled the highlighter successfully and isolated the remaining failure to this missing framework import