### PR TITLE
Use automatic Linux test discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y postgresql libpq-dev cmake
 WORKDIR /app
 
 COPY assets ./assets
-COPY Package.swift Package.resolved LinuxMain.swift ./
+COPY Package.swift Package.resolved ./
 # RUN swift package update
 
 COPY Sources ./Sources


### PR DESCRIPTION
## Summary
- stop copying the legacy `LinuxMain.swift` manifest into the Swift 5.5 Docker build
- let SwiftPM use its automatic Linux test discovery

## Verification
- `swift test --filter TaskTests`
- Heroku native build compiled every app and test module successfully, then failed only while compiling the obsolete root test manifest