### PR TITLE
Fix logging to piped standard streams

### DIFF
--- a/Sources/Base/Logging.swift
+++ b/Sources/Base/Logging.swift
@@ -19,17 +19,14 @@ extension Foundation.FileHandle : TextOutputStream {
 public func log(file: StaticString = #file, line: UInt = #line, _ e: Error) {
     print("ERROR \(file):\(line) ", to: &standardError)
     dump(e, to: &standardError)
-    standardError.synchronizeFile()
 }
 
 public func log(file: StaticString = #file, line: UInt = #line, error: String) {
     print("ERROR \(file):\(line): \(error)", to: &standardError)
-    standardError.synchronizeFile()
 }
 
 public func log(file: StaticString = #file, line: UInt = #line, info: String) {
     print("INFO \(file):\(line): \(info)")
-    FileHandle.standardOutput.synchronizeFile()
 }
 
 @discardableResult
@@ -41,5 +38,4 @@ public func tryOrLog<A>(file: StaticString = #file, line: UInt = #line, _ messag
         return nil
     }
 }
-
 

--- a/Sources/SwiftTalkServerLib/Views/Home.swift
+++ b/Sources/SwiftTalkServerLib/Views/Home.swift
@@ -9,7 +9,7 @@ import Foundation
 import HTML
 
 
-func renderHome(episodes: [EpisodeWithProgress]) -> Node {
+func renderHome(episodes: [EpisodeWithProgress], collections: [Collection] = Collection.all) -> Node {
     let metaDescription = "A video series on Swift programming by Chris Eidhof and Florian Kugler. objc.io publishes books, videos, and articles on advanced techniques for iOS and macOS development."
     let header = Node.header(class: "bgcolor-blue pattern-shade", [
         .div(class: "container", [
@@ -59,7 +59,7 @@ func renderHome(episodes: [EpisodeWithProgress]) -> Node {
                 "Browse all Swift Talk episodes by topic."
             ])
             ]),
-        .ul(class: "cols s+|cols--2n l+|cols--3n", Collection.all.map { coll in
+        .ul(class: "cols s+|cols--2n l+|cols--3n", collections.map { coll in
             .li(class: "col width-full s+|width-1/2 l+|width-1/3 mb++", coll.render())
         })
     ])

--- a/Tests/swifttalkTests/TestBase.swift
+++ b/Tests/swifttalkTests/TestBase.swift
@@ -67,7 +67,7 @@ final class TestBase: XCTestCase {
             connection: noConnection,
             resourcePaths: resourcePaths
         )
-        let html = renderHome(episodes: []).htmlDocument(input: requestEnvironment)
+        let html = renderHome(episodes: [], collections: []).htmlDocument(input: requestEnvironment)
 
         XCTAssertTrue(html.contains("label smallcaps color-blue-darkest bgcolor-orange no-decoration"))
         XCTAssertTrue(html.contains("Archive Mode"))


### PR DESCRIPTION
## Summary
- stop calling `synchronizeFile()` on stdout/stderr pipes after writes
- keep homepage rendering testable by injecting collections with the existing production default
- prevent the archive homepage test from starting unrelated GitHub static-data work

## Verification
- full `swift test`: 19 tests passed
- the previously crashing five-test `FlowTests` suite now passes
- the archive homepage and monthly-only subscribe assertions pass in the full suite