### PR TITLE
Time out stalled Docker package downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM --platform=linux/amd64 swift:5.5.1
 
 RUN set -eux; \
     for attempt in 1 2 3 4 5; do \
-        apt-get -o Acquire::Retries=5 update && \
-        apt-get -o Acquire::Retries=5 install -y \
+        apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
+        apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
             libssl-dev \
             postgresql \
             libpq-dev \


### PR DESCRIPTION
The Ubuntu Bionic mirror can accept a package connection and then stop sending data indefinitely. Add a 30-second APT HTTP timeout so the retry behavior from #137 can recover from stalled connections instead of leaving the Heroku build hung.