### PR TITLE
Use HTTPS Ubuntu mirror for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM --platform=linux/amd64 swift:5.5.1
 
 RUN set -eux; \
+    sed -i \
+        -e 's|http://archive.ubuntu.com/ubuntu|https://mirrors.edge.kernel.org/ubuntu|g' \
+        -e 's|http://security.ubuntu.com/ubuntu|https://mirrors.edge.kernel.org/ubuntu|g' \
+        /etc/apt/sources.list; \
     for attempt in 1 2 3 4 5; do \
-        apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
-        apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
+        apt-get -o Acquire::Retries=5 -o Acquire::https::Timeout=30 update && \
+        apt-get -o Acquire::Retries=5 -o Acquire::https::Timeout=30 install -y \
             libssl-dev \
             postgresql \
             libpq-dev \


### PR DESCRIPTION
Canonical’s plain-HTTP Ubuntu Bionic endpoints are intermittently stalling the Docker build. Rewrite both archive and security sources to the complete Kernel.org HTTPS mirror, which serves both bionic and bionic-security successfully. Keep the existing retry loop and apply its timeout to HTTPS connections.