### PR TITLE
Ignore whitespace in XML arrays

### DIFF
--- a/Sources/SwiftTalkServerLib/ThirdPartyServices/RecurlyXMLDecoder.swift
+++ b/Sources/SwiftTalkServerLib/ThirdPartyServices/RecurlyXMLDecoder.swift
@@ -311,7 +311,7 @@ fileprivate final class RecurlyXMLDecoder: Decoder {
     }
     
     func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        return UDC(nodes: node.childNodes.filter { $0.kind != .invalid }, codingPath: [], currentIndex: 0)
+        return UDC(nodes: node.childNodes.compactMap { $0 as? XMLElement }, codingPath: [], currentIndex: 0)
     }
     
     func singleValueContainer() throws -> SingleValueDecodingContainer {


### PR DESCRIPTION
FoundationXML on Linux exposes whitespace inside empty array elements as text nodes. Restrict the Recurly decoder’s unkeyed container to actual XMLElements so an empty subscription_add_ons element decodes as an empty array instead of attempting to decode whitespace as an add-on. All 19 tests pass locally.